### PR TITLE
Use kt-paperclip as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ parsed from the request body before they are passed to our Rails app.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Choose one from two options and add line to your application's Gemfile:
+
+1.) with [paperclip](https://github.com/thoughtbot/paperclip) dependency, use:
 
     gem 'paperclip-nginx-upload', '~> 1.0'
+
+2.) with [kt-paperclip](https://github.com/kreeti/kt-paperclip) dependency, use:
+
+    gem 'paperclip-nginx-upload', '~> 2.0' 
 
 ## Usage
 

--- a/paperclip-nginx-upload.gemspec
+++ b/paperclip-nginx-upload.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "paperclip", "< 7"
+  spec.add_runtime_dependency "kt-paperclip", "~> 7.0"
 
   spec.add_development_dependency "semmy", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
With this dropping deprecated paperclip dependency.

Using it on test environment, no problems for now.

closes https://github.com/tf/paperclip-nginx-upload/issues/2